### PR TITLE
Blender, UTM, & Azul Fixes

### DIFF
--- a/AzulJDK/AzulJDK21.arm64.download.recipe
+++ b/AzulJDK/AzulJDK21.arm64.download.recipe
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest build of Azul JDK 21 (STS) for arm64</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.download.arm64.azuljdk21</string>
+    <key>Input</key>
+    <dict>
+        <key>BASE_VERSION</key>
+        <string>21</string>
+        <key>ARCHITECTURE</key>
+        <string>arm64</string>
+        <key>ENVIRONMENT</key>
+        <string>jdk</string>
+        <key>NAME</key>
+        <string>AzulJDK %BASE_VERSION%</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.azuljava</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/AzulJDK/AzulJDK21.arm64.munki.recipe
+++ b/AzulJDK/AzulJDK21.arm64.munki.recipe
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads and imports latest arm64 version of AzulJDK 21 (STS) from Zulu.</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.munki.arm64.azuljdk21</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/zulu/azuljdk/%BASE_VERSION%/%ARCHITECTURE%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Azul JDK 21 (STS)</string>
+            <key>developer</key>
+            <string>Zulu</string>
+            <key>display_name</key>
+            <string>%NAME%</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true />
+            <key>supported_architectures</key>
+            <array>
+                <string>%ARCHITECTURE%</string>
+            </array>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.arm64.azuljdk21</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/AzulJDK/AzulJDK21.x86_64.download.recipe
+++ b/AzulJDK/AzulJDK21.x86_64.download.recipe
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest build of Azul JDK 21 (STS) for x86_64</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.download.x86_64.azuljdk21</string>
+    <key>Input</key>
+    <dict>
+        <key>BASE_VERSION</key>
+        <string>21</string>
+        <key>ARCHITECTURE</key>
+        <string>x86_64</string>
+        <key>ENVIRONMENT</key>
+        <string>jdk</string>
+        <key>NAME</key>
+        <string>AzulJDK %BASE_VERSION%</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.azuljava</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/AzulJDK/AzulJDK21.x86_64.munki.recipe
+++ b/AzulJDK/AzulJDK21.x86_64.munki.recipe
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads and imports latest x86_64 version of AzulJDK 21 (STS) from Zulu.</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.munki.x86_64.azuljdk21</string>
+    <key>Input</key>
+    <dict>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/zulu/azuljdk/%BASE_VERSION%/%ARCHITECTURE%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Azul JDK 21 (STS)</string>
+            <key>developer</key>
+            <string>Zulu</string>
+            <key>display_name</key>
+            <string>%NAME%</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true />
+            <key>supported_architectures</key>
+            <array>
+                <string>%ARCHITECTURE%</string>
+            </array>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.x86_64.azuljdk21</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/AzulJDK/AzulURLProvider.py
+++ b/AzulJDK/AzulURLProvider.py
@@ -59,11 +59,12 @@ class AzulURLProvider(URLGetter):
 
         # Use the download feature of URLGetter (yay subclasses)
         version_page = self.download(BASEURL, text=True)
-
         # Craft regex to scrape for our specified version (returns tuples)
         version_arch = ARCHITECTURES[self.env["arch"]]
         re_basever = "%s".replace(".", "\.") % self.env["base_version"]
-        re_match = re.compile("\"zulu(.*)-ca-(%s%s.*)-%s_%s.dmg\"" % ( self.env["environment"], re_basever, OS, version_arch ))
+        re_match = re.compile(
+            "\"\/zulu\/bin\/zulu(.*)-ca-(%s%s.*)-%s_%s.dmg\"" % ( self.env["environment"], re_basever, OS, version_arch )
+        )
         version_matches = re.findall(re_match, version_page)
         self.output("Checking versions for %s (%s)" % ( self.env["base_version"], version_arch ))
 

--- a/Blender/Blender.arm64.download.recipe
+++ b/Blender/Blender.arm64.download.recipe
@@ -13,7 +13,7 @@
         <key>ARCHITECTURE</key>
         <string>arm64</string>
         <key>MIRROR_OVERRIDE</key>
-        <string></string>
+        <string />
         <key>NAME</key>
         <string>Blender</string>
     </dict>

--- a/Blender/Blender.arm64.download.recipe
+++ b/Blender/Blender.arm64.download.recipe
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest build of Blender for arm64</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.download.arm64.blender</string>
+    <key>Input</key>
+    <dict>
+        <key>BASE_VERSION</key>
+        <string></string>
+        <key>ARCHITECTURE</key>
+        <string>arm64</string>
+        <key>MIRROR_OVERRIDE</key>
+        <string></string>
+        <key>NAME</key>
+        <string>Blender</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.blender</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Blender/Blender.arm64.munki.recipe
+++ b/Blender/Blender.arm64.munki.recipe
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest build of Blender for arm64</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.munki.arm64.blender</string>
+    <key>Input</key>
+    <dict>
+        <key>BASE_VERSION</key>
+        <string></string>
+        <key>MIRROR_OVERRIDE</key>
+        <string></string>
+        <key>NAME</key>
+        <string>Blender</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/blenderfoundation/blender/%BASE_VERSION%/%ARCHITECTURE%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Blender is a public project hosted on blender.org, licensed as GNU GPL, owned by its contributors.</string>
+            <key>developer</key>
+            <string>Blender</string>
+            <key>display_name</key>
+            <string>%NAME%</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true />
+            <key>supported_architectures</key>
+            <array>
+                <string>%ARCHITECTURE%</string>
+            </array>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.arm64.blender</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+       <key>Description</key>
+    <string>Downloads the latest build of Blender for the specified achitecture and version</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.download.blender</string>
+    <key>Input</key>
+    <dict>
+        <key>BASE_VERSION</key>
+        <string>0</string>
+        <key>ARCHITECTURE</key>
+        <string />
+        <key>MIRROR_OVERRIDE</key>
+        <string />
+        <key>NAME</key>
+        <string>Blender Unspecified</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>BlenderURLProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>base_version</key>
+                <string>%BASE_VERSION%</string>
+                <key>arch</key>
+                <string>%ARCHITECTURE%</key>
+                <key>mirror_override_rule</key>
+                <string>%MIRROR_OVERRIDE%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%download_url%</string>
+                <key>filename</key>
+                <string>%download_file%</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/Blender.app</string>
+                <key>requirement</key>
+                <string>identifier "org.blenderfoundation.blender" and anchor apple generic and certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = "68UA947AUU"</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -30,7 +30,7 @@
                 <string>%BASE_VERSION%</string>
                 <key>arch</key>
                 <string>%ARCHITECTURE%</string>
-                <key>mirror_override_rule</key>
+                <key>mirror_override_url</key>
                 <string>%MIRROR_OVERRIDE%</string>
             </dict>
         </dict>

--- a/Blender/Blender.download.recipe
+++ b/Blender/Blender.download.recipe
@@ -29,7 +29,7 @@
                 <key>base_version</key>
                 <string>%BASE_VERSION%</string>
                 <key>arch</key>
-                <string>%ARCHITECTURE%</key>
+                <string>%ARCHITECTURE%</string>
                 <key>mirror_override_rule</key>
                 <string>%MIRROR_OVERRIDE%</string>
             </dict>

--- a/Blender/Blender.x86_64.download.recipe
+++ b/Blender/Blender.x86_64.download.recipe
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest build of Blender for x86_64</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.download.x86_64.blender</string>
+    <key>Input</key>
+    <dict>
+        <key>BASE_VERSION</key>
+        <string></string>
+        <key>ARCHITECTURE</key>
+        <string>x86_64</string>
+        <key>MIRROR_OVERRIDE</key>
+        <string></string>
+        <key>NAME</key>
+        <string>Blender</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.blender</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Blender/Blender.x86_64.munki.recipe
+++ b/Blender/Blender.x86_64.munki.recipe
@@ -1,0 +1,53 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest build of Blender for x86_64</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.munki.x86_64.blender</string>
+    <key>Input</key>
+    <dict>
+        <key>BASE_VERSION</key>
+        <string></string>
+        <key>MIRROR_OVERRIDE</key>
+        <string></string>
+        <key>NAME</key>
+        <string>Blender</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/blenderfoundation/blender/%BASE_VERSION%/%ARCHITECTURE%</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>testing</string>
+            </array>
+            <key>description</key>
+            <string>Blender is a public project hosted on blender.org, licensed as GNU GPL, owned by its contributors.</string>
+            <key>developer</key>
+            <string>Blender</string>
+            <key>display_name</key>
+            <string>%NAME%</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true />
+            <key>supported_architectures</key>
+            <array>
+                <string>%ARCHITECTURE%</string>
+            </array>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.x86_64.blender</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/Blender/BlenderURLprovider.py
+++ b/Blender/BlenderURLprovider.py
@@ -17,7 +17,6 @@ from autopkglib.URLGetter import URLGetter
 # https://www.blender.org/download/release/Blender4.0/blender-4.0.2-macos-x64.dmg/
 pre_mirror_url = 'https://www.blender.org/download/release/'
 os_str = 'macos'
-arch_str = ''
 
 archs = {
     'arm64': 'arm64',
@@ -31,13 +30,17 @@ class BlenderURLProvider( URLGetter ):
 
     # autopkg input
     input_variables = {
+        'arch' : {
+            'required': True,
+            'description': "Specify architecture of the the environment ('x86_64', or 'arm64'))"
+        },
         'base_version' : {
             'required': True,
             'description': "Base blender version (format: 'x.y')"
         },
-        'arch' : {
+        'mirror_override_url' : {
             'required': True,
-            'description': "Specify architecture of the the environment ('x86_64', or 'arm64'))"
+            'description': "Use the specified mirror URL (incl. trailing '/', exclude 'BlenderX.Y')"
         }
     }
 
@@ -48,43 +51,65 @@ class BlenderURLProvider( URLGetter ):
         },
         'download_version': {
             'description': "Version of jre/jdk to from the download_url"
+        },
+        'download_file': {
+            'description': "Full filename of download"
         }
     }
 
-
     def getDownloadURL( self ):
         # Combine mirror url with version specified from recipe
-        release_url = '%s/Blender%s/' % ( pre_mirror_url, self.env['base_version'] )
-        # Use the download feature of URLGetter
-        release_index_page = self.download(release_url, text=True)
-
+        release_url = '%sBlender%s/' % ( pre_mirror_url, self.env['base_version'] )
+        if '%s' % self.env['mirror_override_url']:
+            # We're overriding the mirror
+            release_override_url = ( '%sBlender%s/' % ( self.env['mirror_override_url'], self.env['base_version'] ) )
+            release_index_page = self.download( release_override_url, text=True )
+        else:
+            # Use the download feature of URLGetter
+            release_index_page = self.download( release_url, text=True )
+        
         # Time for regex
         # Grab all subversions available for our os / arch
         re_match_all_macos = re.compile(
-            'blender-%s.\d-%s-%s.dmg' % ( self.env['base_version'], os_str,  arch_str )
+            '\"blender-%s.\d-%s-%s\.dmg\"' % ( self.env['base_version'], os_str,  archs[self.env['arch']] )
         )
         matched_vers_for_arch = re.findall( re_match_all_macos, release_index_page )
+
         # Make sure we actually got something here
         if not matched_vers_for_arch:
-            raise ProcessorError( 'No versions found with the base version provided %s and arch of %s' % ( self.env['base_version'], arch_str ) )
-        # We've got something
-        matched_vers_for_arch = sorted( matched_vers_for_arch, key = lambda tup: tup[1], reverse = True )
+            raise ProcessorError( 'No versions found with the base version provided %s (%s)' % ( self.env['base_version'], archs[self.env['arch']] ) )
         
+        # We've got something, sort for latest (second entry when split by '-')
+        matched_vers_for_arch = sorted( matched_vers_for_arch, key = lambda s: s.split('-')[1], reverse = True )
+        self.output( 'Found %s versions for %s (%s)' % ( len(matched_vers_for_arch), self.env['base_version'], archs[self.env['arch']] ) )
+        matched_latest_vers_item = matched_vers_for_arch[0]
+        matched_latest_vers_dmg = matched_latest_vers_item.replace( '\"', '' )
+        matched_latest_vers = matched_latest_vers_dmg.split( '-' )[1]
+        self.env['download_file'] = matched_latest_vers_dmg
+        self.env['download_version'] = matched_latest_vers
+        self.output( 'Latest version of (%s) is %s.' % ( self.env['base_version'], matched_latest_vers ) )
 
-
+        # We have what we need, craft the URL
+        if '%s' % self.env['mirror_override_url']:
+            # Override if provided
+            latest_vers_url = self.env['mirror_override_url'] + 'Blender' + self.env['base_version'] + '/' + matched_latest_vers_dmg
+        else:
+            # Use Blender URL
+            latest_vers_url = pre_mirror_url + 'Blender' + self.env['base_version'] + '/' + matched_latest_vers_dmg
+        self.env['download_url'] = latest_vers_url
+        self.output( 'URL for %s (%s) is: %s' % ( matched_latest_vers_dmg[1], archs[self.env['arch']], latest_vers_url ) )
+        
     def main( self ):
         # Check for valid arch
-        if "%s" % self.env['arch'] in archs:
-            # Set arch_string for sugar
-            arch_str = '%s' % archs[self.env['arch']]
+        if '%s' % self.env['arch'] in archs:
             # Grab URL based on arch
-            self.output( 'Getting URL for Blender %s for %s (%s)', ( self.env['base_version'], os_str, self.env['arch'] ) )
+            self.output( 'Getting URL for Blender %s for %s (%s)' % ( self.env['base_version'], os_str, self.env['arch'] ) )
             try:
                 self.getDownloadURL()
             except Exception as err:
                 raise ProcessorError(err)
 
             
-if __name__ == "__main__":
+if __name__ == '__main__':
     PROCESSOR = BlenderURLProvider()
     PROCESSOR.execute_shell()

--- a/Blender/BlenderURLprovider.py
+++ b/Blender/BlenderURLprovider.py
@@ -1,0 +1,90 @@
+#!/usr/local/autopkg/python
+#
+# Copyright 2024 Ashe Night
+#
+# Licensed under the Educational Community License, Version 2.0 (ECL-2.0);
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://opensource.org/licenses/ECL-2.0
+#
+
+import re
+
+from autopkglib import ProcessorError
+from autopkglib.URLGetter import URLGetter
+
+# https://www.blender.org/download/release/Blender4.0/blender-4.0.2-macos-x64.dmg/
+pre_mirror_url = 'https://www.blender.org/download/release/'
+os_str = 'macos'
+arch_str = ''
+
+archs = {
+    'arm64': 'arm64',
+    'x86_64': 'x64'
+}
+
+__all__ = [ 'BlenderURLProvider' ]
+
+class BlenderURLProvider( URLGetter ):
+    description = __doc__
+
+    # autopkg input
+    input_variables = {
+        'base_version' : {
+            'required': True,
+            'description': "Base blender version (format: 'x.y')"
+        },
+        'arch' : {
+            'required': True,
+            'description': "Specify architecture of the the environment ('x86_64', or 'arm64'))"
+        }
+    }
+
+    # autopkg output
+    output_variables = {
+        'download_url': {
+            'description': "URL for downloading the latest version of Blender"
+        },
+        'download_version': {
+            'description': "Version of jre/jdk to from the download_url"
+        }
+    }
+
+
+    def getDownloadURL( self ):
+        # Combine mirror url with version specified from recipe
+        release_url = '%s/Blender%s/' % ( pre_mirror_url, self.env['base_version'] )
+        # Use the download feature of URLGetter
+        release_index_page = self.download(release_url, text=True)
+
+        # Time for regex
+        # Grab all subversions available for our os / arch
+        re_match_all_macos = re.compile(
+            'blender-%s.\d-%s-%s.dmg' % ( self.env['base_version'], os_str,  arch_str )
+        )
+        matched_vers_for_arch = re.findall( re_match_all_macos, release_index_page )
+        # Make sure we actually got something here
+        if not matched_vers_for_arch:
+            raise ProcessorError( 'No versions found with the base version provided %s and arch of %s' % ( self.env['base_version'], arch_str ) )
+        # We've got something
+        matched_vers_for_arch = sorted( matched_vers_for_arch, key = lambda tup: tup[1], reverse = True )
+        
+
+
+    def main( self ):
+        # Check for valid arch
+        if "%s" % self.env['arch'] in archs:
+            # Set arch_string for sugar
+            arch_str = '%s' % archs[self.env['arch']]
+            # Grab URL based on arch
+            self.output( 'Getting URL for Blender %s for %s (%s)', ( self.env['base_version'], os_str, self.env['arch'] ) )
+            try:
+                self.getDownloadURL()
+            except Exception as err:
+                raise ProcessorError(err)
+
+            
+if __name__ == "__main__":
+    PROCESSOR = BlenderURLProvider()
+    PROCESSOR.execute_shell()

--- a/Docker/Docker.arm64.munki.recipe
+++ b/Docker/Docker.arm64.munki.recipe
@@ -14,7 +14,7 @@
         <dict>
             <key>catalogs</key>
             <array>
-                <string>Testing</string>
+                <string>testing</string>
             </array>
             <key>description</key>
             <string>Docker Desktop - the fastest way to containerize applications.</string>

--- a/Docker/Docker.x86_64.munki.recipe
+++ b/Docker/Docker.x86_64.munki.recipe
@@ -14,7 +14,7 @@
         <dict>
             <key>catalogs</key>
             <array>
-                <string>Testing</string>
+                <string>testing</string>
             </array>
             <key>description</key>
             <string>Docker Desktop - the fastest way to containerize applications.</string>

--- a/Stats/Stats.universal.munki.recipe
+++ b/Stats/Stats.universal.munki.recipe
@@ -16,7 +16,7 @@
         <dict>
             <key>catalogs</key>
             <array>
-                <string>Testing</string>
+                <string>testing</string>
             </array>
             <key>description</key>
             <string>Stats is an application that allows you to monitor your macOS system.</string>

--- a/UTM/UTM.download.recipe
+++ b/UTM/UTM.download.recipe
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads the latest version of UTM from Github</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.download.utm</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>UTM</string>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>Process</key>
+    <array>
+        <dict>
+            <key>Processor</key>
+            <string>GitHubReleasesInfoProvider</string>
+            <key>Arguments</key>
+            <dict>
+                <key>github_repo</key>
+                <string>utmapp/UTM</string>
+                <key>asset_regex</key>
+                <string>.*\.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>URLDownloader</string>
+            <key>Arguments</key>
+            <dict>
+                <key>url</key>
+                <string>%url%</string>
+                <key>filename</key>
+                <string>%NAME%-%version%.dmg</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>EndOfCheckPhase</string>
+        </dict>
+        <dict>
+            <key>Processor</key>
+            <string>CodeSignatureVerifier</string>
+            <key>Arguments</key>
+            <dict>
+                <key>input_path</key>
+                <string>%pathname%/UTM.app</string>
+                <key>requirement</key>
+                <string>anchor apple generic and identifier "com.utmapp.UTM" and (certificate leaf[field.1.2.840.113635.100.6.1.9] /* exists */ or certificate 1[field.1.2.840.113635.100.6.2.6] /* exists */ and certificate leaf[field.1.2.840.113635.100.6.1.13] /* exists */ and certificate leaf[subject.OU] = WDNLXAD4W8)</string>    
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/UTM/UTM.munki.recipe
+++ b/UTM/UTM.munki.recipe
@@ -9,7 +9,7 @@
     <key>Input</key>
     <dict>
         <key>NAME</key>
-        <string>Stats</string>
+        <string>UTM</string>
         <key>MUNKI_REPO_SUBDIR</key>
         <string>apps/utm</string>
         <key>pkginfo</key>

--- a/UTM/UTM.munki.recipe
+++ b/UTM/UTM.munki.recipe
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Description</key>
+    <string>Downloads an imports the latest version of UTM from Github</string>
+    <key>Identifier</key>
+    <string>com.github.ashesamurai.munki.utm</string>
+    <key>Input</key>
+    <dict>
+        <key>NAME</key>
+        <string>Stats</string>
+        <key>MUNKI_REPO_SUBDIR</key>
+        <string>apps/utm</string>
+        <key>pkginfo</key>
+        <dict>
+            <key>catalogs</key>
+            <array>
+                <string>Testing</string>
+            </array>
+            <key>description</key>
+            <string>UTM is a full featured system emulator and virtual machine host for iOS and macOS.</string>
+            <key>developer</key>
+            <string>UTM</string>
+            <key>display_name</key>
+            <string>%NAME%</string>
+            <key>name</key>
+            <string>%NAME%</string>
+            <key>unattended_install</key>
+            <true />
+            <key>supported_architectures</key>
+            <array>
+                <string>arm64</string>
+            </array>
+        </dict>
+    </dict>
+    <key>MinimumVersion</key>
+    <string>2.3</string>
+    <key>ParentRecipe</key>
+    <string>com.github.ashesamurai.download.utm</string>
+    <key>Process</key>
+    <array>
+      <dict>
+            <key>Processor</key>
+            <string>MunkiImporter</string>
+            <key>Arguments</key>
+            <dict>
+                <key>pkg_path</key>
+                <string>%pathname%</string>
+                <key>repo_subdirectory</key>
+                <string>%MUNKI_REPO_SUBDIR%</string>
+            </dict>
+        </dict>
+    </array>
+</dict>
+</plist>

--- a/UTM/UTM.munki.recipe
+++ b/UTM/UTM.munki.recipe
@@ -16,7 +16,7 @@
         <dict>
             <key>catalogs</key>
             <array>
-                <string>Testing</string>
+                <string>testing</string>
             </array>
             <key>description</key>
             <string>UTM is a full featured system emulator and virtual machine host for iOS and macOS.</string>

--- a/ardkick/ardkick.munki.recipe
+++ b/ardkick/ardkick.munki.recipe
@@ -16,7 +16,7 @@
         <dict>
             <key>catalogs</key>
             <array>
-                <string>Testing</string>
+                <string>testing</string>
             </array>
             <key>description</key>
             <string>Quick script to run after remotely ssh'ing to a Mac. Running ardkick as sudo will restart the ARDAgent.</string>


### PR DESCRIPTION
- Added Blender recipes (tbd: `remove mirror_override_url` requirement)
- Added UTM recipe
- Fixed issue with `AzulURLProvider` no longer being able to parse the downloads page
- Added Azul JDK 21 recipes